### PR TITLE
Correction issue

### DIFF
--- a/input/fsh/extensions/RORHealthcareServiceContact.fsh
+++ b/input/fsh/extensions/RORHealthcareServiceContact.fsh
@@ -12,13 +12,9 @@ Description: "Extension créée dans le cadre du ROR pour décrire la personne o
     purposeContact 0..1 and
     description 0..1 and
     RORConfidentialityLevel named ror-confidentiality-level 1..1 and
-    RORTelecomCommunicationChannel named ror-telecom-communication-channel 1..1 and
-    RORTelecomUsage named ror-telecom-usage 0..1 and
-    RORTelecomConfidentialityLevel named ror-telecom-confidentiality-level 1..1 and
-    telecomAddress 1..1
+    RORHealthcareServiceContactTelecom named ror-healthcareservice-contact-telecom 0..*
 * extension[name].value[x] only string
 * extension[description].value[x] only string
-* extension[telecomAddress].value[x] only string
 * extension[purposeContact].value[x] only CodeableConcept
 * extension[purposeContact].valueCodeableConcept from $JDV-J221-NatureContact-ROR (required)
 

--- a/input/fsh/extensions/RORHealthcareServiceContactTelecom.fsh
+++ b/input/fsh/extensions/RORHealthcareServiceContactTelecom.fsh
@@ -1,5 +1,5 @@
 Extension: RORHealthcareServiceContactTelecom
-Id: ror-healthcareservice-contatc-telecom
+Id: ror-healthcareservice-contact-telecom
 Description: "Extension créée dans le cadre du ROR pour les télécommunications du contact."
 * ^context.type = #element
 * ^context.expression = "https://interop.esante.gouv.fr/ig/fhir/ror/StructureDefinition/ror-healthcareservice-contact"

--- a/input/fsh/extensions/RORHealthcareServiceContactTelecom.fsh
+++ b/input/fsh/extensions/RORHealthcareServiceContactTelecom.fsh
@@ -1,0 +1,14 @@
+Extension: RORHealthcareServiceContactTelecom
+Id: ror-healthcareservice-contatc-telecom
+Description: "Extension créée dans le cadre du ROR pour les télécommunications du contact."
+* ^context.type = #element
+* ^context.expression = "https://interop.esante.gouv.fr/ig/fhir/ror/StructureDefinition/ror-healthcareservice-contact"
+* extension ^slicing.discriminator.type = #value
+* extension ^slicing.discriminator.path = "url"
+* extension ^slicing.rules = #open
+* extension contains
+    RORTelecomCommunicationChannel named ror-telecom-communication-channel 1..1 and
+    RORTelecomUsage named ror-telecom-usage 0..1 and
+    RORTelecomConfidentialityLevel named ror-telecom-confidentiality-level 1..1 and
+    telecomAddress 1..1
+* extension[telecomAddress].value[x] only string

--- a/input/fsh/extensions/RORTelecomCommunicationChannel.fsh
+++ b/input/fsh/extensions/RORTelecomCommunicationChannel.fsh
@@ -4,6 +4,6 @@ Description: "Extension créée dans le cadre du ROR spécifiant le canal ou la 
 * ^context[0].type = #element
 * ^context[=].expression = "ContactPoint"
 * ^context[+].type = #extension
-* ^context[=].expression = "https://interop.esante.gouv.fr/ig/fhir/ror/StructureDefinition/ror-healthcareservice-contact"
+* ^context[=].expression = "https://interop.esante.gouv.fr/ig/fhir/ror/StructureDefinition/ror-healthcareservice-contact-telecom"
 * value[x] only CodeableConcept
 * valueCodeableConcept from $JDV-J225-CanalCommunication-ROR (required)

--- a/input/fsh/extensions/RORTelecomConfidentialityLevel.fsh
+++ b/input/fsh/extensions/RORTelecomConfidentialityLevel.fsh
@@ -4,6 +4,6 @@ Description: "Extension créée dans le cadre du ROR qui permet de définir le n
 * ^context[0].type = #element
 * ^context[=].expression = "ContactPoint"
 * ^context[+].type = #extension
-* ^context[=].expression = "https://interop.esante.gouv.fr/ig/fhir/ror/StructureDefinition/ror-healthcareservice-contact"
+* ^context[=].expression = "https://interop.esante.gouv.fr/ig/fhir/ror/StructureDefinition/ror-healthcareservice-contact-telecom"
 * value[x] only CodeableConcept
 * valueCodeableConcept from $JDV-J222-NiveauConfidentialite-ROR (required)

--- a/input/fsh/extensions/RORTelecomUsage.fsh
+++ b/input/fsh/extensions/RORTelecomUsage.fsh
@@ -4,5 +4,5 @@ Description: "Extension créée dans le cadre du ROR qui précise l'utilisation 
 * ^context[0].type = #element
 * ^context[=].expression = "ContactPoint"
 * ^context[+].type = #extension
-* ^context[=].expression = "https://interop.esante.gouv.fr/ig/fhir/ror/StructureDefinition/ror-healthcareservice-contact"
+* ^context[=].expression = "https://interop.esante.gouv.fr/ig/fhir/ror/StructureDefinition/ror-healthcareservice-contact-telecom"
 * value[x] only string


### PR DESCRIPTION
Les attributs liés à télécommunication ont été déplacés dans une extension à part (RORHealthcareServiceContactTelecom), qui est appelée dans l'extension RORHealthcareServiceContact avec pour cardinalité 0..*.