### PR TITLE
suppr scenario 2 signalement ano

### DIFF
--- a/input/pagecontent/specifications_fonctionnelles.md
+++ b/input/pagecontent/specifications_fonctionnelles.md
@@ -443,9 +443,10 @@ Le ROR National répond au consommateur l’identifiant technique, les métadonn
 
 -	Scenario 1 : Signalement d’une anomalie
     -	Un responsable qualité souhaite signaler une anomalie sur un élément.
-
+<!-- suppression scenario à la demande du ROR cf issue https://github.com/ansforge/IG-fhir-repertoire-offre-ressources-sante/issues/207 
 -	Scenario 2 : Signalement de plusieurs anomalies
     -	Un consommateur d'un système tiers souhaite signaler plusieurs anomalies.
+-->
 
 **Les spécifications techniques pour répondre à ce cas d'usage sont accessibles [ici](specifications_techniques_5.html)**
 

--- a/input/pagecontent/specifications_fonctionnelles.md
+++ b/input/pagecontent/specifications_fonctionnelles.md
@@ -445,8 +445,7 @@ Le ROR National répond au consommateur l’identifiant technique, les métadonn
     -	Un responsable qualité souhaite signaler une anomalie sur un élément.
 <!-- suppression scenario à la demande du ROR cf issue https://github.com/ansforge/IG-fhir-repertoire-offre-ressources-sante/issues/207 
 -	Scenario 2 : Signalement de plusieurs anomalies
-    -	Un consommateur d'un système tiers souhaite signaler plusieurs anomalies.
--->
+    -	Un consommateur d'un système tiers souhaite signaler plusieurs anomalies. -->
 
 **Les spécifications techniques pour répondre à ce cas d'usage sont accessibles [ici](specifications_techniques_5.html)**
 

--- a/input/pagecontent/specifications_fonctionnelles.md
+++ b/input/pagecontent/specifications_fonctionnelles.md
@@ -443,9 +443,12 @@ Le ROR National répond au consommateur l’identifiant technique, les métadonn
 
 -	Scenario 1 : Signalement d’une anomalie
     -	Un responsable qualité souhaite signaler une anomalie sur un élément.
-<!-- suppression scenario à la demande du ROR cf issue https://github.com/ansforge/IG-fhir-repertoire-offre-ressources-sante/issues/207 
+
+<!---
+suppression scenario à la demande du ROR cf issue https://github.com/ansforge/IG-fhir-repertoire-offre-ressources-sante/issues/207 
 -	Scenario 2 : Signalement de plusieurs anomalies
-    -	Un consommateur d'un système tiers souhaite signaler plusieurs anomalies. -->
+    -	Un consommateur d'un système tiers souhaite signaler plusieurs anomalies.
+--->
 
 **Les spécifications techniques pour répondre à ce cas d'usage sont accessibles [ici](specifications_techniques_5.html)**
 

--- a/input/pagecontent/specifications_techniques_5.md
+++ b/input/pagecontent/specifications_techniques_5.md
@@ -148,6 +148,7 @@ POST [BASE]/Task
 }
 ```
 
+<!-- suppression scenario à la demande du ROR cf issue https://github.com/ansforge/IG-fhir-repertoire-offre-ressources-sante/issues/207 
 #### Scénario 2 : Signalement de plusieurs anomalies
 
 **Description du scénario :** Le moteur de règle crée automatiquement une ou plusieurs anomalies sur un ou plusieurs éléments.
@@ -184,3 +185,4 @@ POST [BASE]/Bundle
 	]
 }
 ```
+-->


### PR DESCRIPTION
comme convenu:
https://ansforge.github.io/IG-fhir-repertoire-offre-ressources-sante/ig/sd-suppr-scenario-2-signalement-ano/specifications_techniques_5.html

et 

https://ansforge.github.io/IG-fhir-repertoire-offre-ressources-sante/ig/sd-suppr-scenario-2-signalement-ano/specifications_fonctionnelles.html#sc%C3%A9narios-7