### PR TITLE
Création extension lieu dit

### DIFF
--- a/input/fsh/extensions/AsLieuDit.fsh
+++ b/input/fsh/extensions/AsLieuDit.fsh
@@ -1,6 +1,7 @@
 Extension: AsLieuDit
 Id: as-ext-lieu-dit
 Description: "Extension créée dans le cadre du ROR pour indiquer le lieu dit"
+* ^url = "https://interop.esante.gouv.fr/ig/fhir/annuaire/StructureDefinition/as-ext-lieu-dit"
 * ^context[0].type = #element
 * ^context[=].expression = "Address.line"
 * value[x] only string

--- a/input/fsh/extensions/AsLieuDit.fsh
+++ b/input/fsh/extensions/AsLieuDit.fsh
@@ -1,5 +1,5 @@
-Extension: RORLieuDit
-Id: ror-lieu-dit
+Extension: AsLieuDit
+Id: as-ext-lieu-dit
 Description: "Extension créée dans le cadre du ROR pour indiquer le lieu dit"
 * ^context[0].type = #element
 * ^context[=].expression = "Address.line"

--- a/input/fsh/extensions/RORLieuDit.fsh
+++ b/input/fsh/extensions/RORLieuDit.fsh
@@ -1,0 +1,7 @@
+Extension: RORLieuDit
+Id: ror-lieu-dit
+Description: "Extension créée dans le cadre du ROR pour indiquer le lieu dit"
+* ^context[0].type = #element
+* ^context[=].expression = "Address.line"
+* value[x] only string
+

--- a/input/fsh/profiles/RORLocation.fsh
+++ b/input/fsh/profiles/RORLocation.fsh
@@ -72,7 +72,7 @@ Description: "Profil créé dans le cadre du ROR pour décrire l'espace disposan
     iso21090-ADXP-streetNameType named streetNameType 0..1 and
     iso21090-ADXP-streetNameBase named streetNameBase 0..1 and
     iso21090-ADXP-postBox named postalBox 0..1 and
-    ror-lieu-dit named lieuDit 0..1
+    as-ext-lieu-dit named lieuDit 0..1
 * address.line.extension[careOf] ^short = "pointRemise (Adresse) : Lieu où le destinataire prend possession de son courrier"
 * address.line.extension[additionalLocator] ^short = "complementPointGeographique (Adresse) : Un complément de l'adresse au point géographique"
 * address.line.extension[houseNumber] ^short = "numeroVoie (Adresse) : Un numéro dans la voie"

--- a/input/fsh/profiles/RORLocation.fsh
+++ b/input/fsh/profiles/RORLocation.fsh
@@ -71,8 +71,8 @@ Description: "Profil créé dans le cadre du ROR pour décrire l'espace disposan
     iso21090-ADXP-buildingNumberSuffix named buildingNumberSuffix 0..1 and
     iso21090-ADXP-streetNameType named streetNameType 0..1 and
     iso21090-ADXP-streetNameBase named streetNameBase 0..1 and
-    iso21090-ADXP-precinct named precinct 0..1 and
-    iso21090-ADXP-postBox named postalBox 0..1
+    iso21090-ADXP-postBox named postalBox 0..1 and
+    ror-lieu-dit named lieuDit 0..1
 * address.line.extension[careOf] ^short = "pointRemise (Adresse) : Lieu où le destinataire prend possession de son courrier"
 * address.line.extension[additionalLocator] ^short = "complementPointGeographique (Adresse) : Un complément de l'adresse au point géographique"
 * address.line.extension[houseNumber] ^short = "numeroVoie (Adresse) : Un numéro dans la voie"
@@ -80,8 +80,8 @@ Description: "Profil créé dans le cadre du ROR pour décrire l'espace disposan
 * address.line.extension[streetNameType] ^short = "typeVoie (Adresse) : Type de voie"
 * address.line.extension[streetNameType].valueString from $JDV-J219-TypeVoie-ROR (required)
 * address.line.extension[streetNameBase] ^short = "libelleVoie (Adresse) : Appellation qui est donnée à la voie par les municipalités"
-* address.line.extension[precinct] ^short = "lieuDit (Adresse) : Lieu qui porte un nom rappelant une particularité topographique ou historique"
 * address.line.extension[postalBox] ^short = "mentionDistribution (Adresse) : Mentions particulières de distribution"
+* address.line.extension[lieuDit] ^short = "lieuDit (Adresse) : Lieu qui porte un nom rappelant une particularité topographique ou historique"
 
 * position ^short = "coordonneeGeographique (LieuRealisationOffre) : Coordonnées géographiques du lieu (système géodésique : WGS84)"
 * position.latitude ^short = "latitude (CoordonneeGeographique) : Une mesure de la distance angulaire nord ou sud depuis l'équateur jusqu'au parallèle du spécifique"

--- a/input/fsh/profiles/ROROrganization.fsh
+++ b/input/fsh/profiles/ROROrganization.fsh
@@ -140,7 +140,7 @@ ou nom de l'OI : Nom de l'organisation interne"
     iso21090-ADXP-streetNameType named streetNameType 0..1 and
     iso21090-ADXP-postBox named postalBox 0..1 and
     iso21090-ADXP-streetNameBase named streetNameBase 0..1 and
-    ror-lieu-dit named lieuDit 0..1
+    as-ext-lieu-dit named lieuDit 0..1
 * address.line.extension[careOf] ^short = "pointRemise (Adresse)"
 * address.line.extension[additionalLocator] ^short = "complementPointGeographique (Adresse)"
 * address.line.extension[houseNumber] ^short = "numeroVoie(Adresse)"

--- a/input/fsh/profiles/ROROrganization.fsh
+++ b/input/fsh/profiles/ROROrganization.fsh
@@ -139,8 +139,8 @@ ou nom de l'OI : Nom de l'organisation interne"
     iso21090-ADXP-buildingNumberSuffix named buildingNumberSuffix 0..1 and
     iso21090-ADXP-streetNameType named streetNameType 0..1 and
     iso21090-ADXP-postBox named postalBox 0..1 and
-    iso21090-ADXP-streetNameBase named streetNameBase 0..* and
-    iso21090-ADXP-precinct named precinct 0..*
+    iso21090-ADXP-streetNameBase named streetNameBase 0..1 and
+    ror-lieu-dit named lieuDit 0..1
 * address.line.extension[careOf] ^short = "pointRemise (Adresse)"
 * address.line.extension[additionalLocator] ^short = "complementPointGeographique (Adresse)"
 * address.line.extension[houseNumber] ^short = "numeroVoie(Adresse)"
@@ -149,7 +149,7 @@ ou nom de l'OI : Nom de l'organisation interne"
 * address.line.extension[streetNameType].valueString from $JDV-J219-TypeVoie-ROR (required)
 * address.line.extension[postalBox] ^short = "mentionDistribution (Adresse)"
 * address.line.extension[streetNameBase] ^short = "libelleVoie (Adresse)"
-* address.line.extension[precinct] ^short = "lieuDit (Adresse)"
+* address.line.extension[lieuDit] ^short = "lieuDit (Adresse)"
 
 
 * telecom.value 1..1


### PR DESCRIPTION
## Description des changements

Création d'une extension pour le lieuDit afin de remplacer iso21090-ADXP-precinct qui s'applique au niveau de address et non pas de address.line

Remarque : Nous avons remarqué que la cardinalité des éléments streetNameBase (libelleVoie) et lieuDit de address.line étaient différentes entre les ressources Organization et Location, elles ont été corrigées en cohérence avec le ME.

## Preview

[https://ansforge.github.io/IG-fhir-repertoire-offre-ressources-sante/ig/[nom_de_la_branche] pour prévisualiser l'IG d'une branche](https://ansforge.github.io/IG-fhir-repertoire-offre-ressources-sante/ig/291-erreur-organization-lieu-dit-precinct/)

## Impact API ROR

@jcserafini impact dev