### PR TITLE
[test]add dependance ig NOS

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -13,6 +13,7 @@ dependencies:
   hl7.fhir.fr.core: 1.1.0
   hl7.fhir.uv.bulkdata: 2.0.0
   ans.fr.securisation-transport: 1.2.0
+  ans.fr.nos: 1.2.0
 status: active
 version: 0.2.1
 fhirVersion: 4.0.1


### PR DESCRIPTION
## Description des changements

ajout de la dépendance à l'IG du NOS versionné
Changement : redirection des liens sur l'IG ROR au niveau du binding par exemple

## Preview

https://ansforge.github.io/IG-fhir-repertoire-offre-ressources-sante/sd-test-add-igNOS/ig/ pour prévisualiser l'IG d'une branche

## Impact API ROR
Pas de changements dans les json des SD donc normalement pas d'impact
permet d'utiliser une version du NOS packagé et pouvoir prévoir les évolutions du NOS exemple : https://interop.esante.gouv.fr/ig/nos/1.2.0/ValueSet-JDV-J237-RegionOM-ROR.html