### PR TITLE
Specialty - Savoir faire, activité opérationnelle

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -11,6 +11,7 @@ Alias: $TRE-G07-TypeIdentifiantStructure = https://mos.esante.gouv.fr/NOS/TRE_G0
 Alias: $TRE-R345-TypeIdentifiantAutre = https://mos.esante.gouv.fr/NOS/TRE_R345-TypeIdentifiantAutre/FHIR/TRE-R345-TypeIdentifiantAutre
 Alias: $TRE-R354-TypeIdentifiantRessourceOperationnelle = https://mos.esante.gouv.fr/NOS/TRE_R354-TypeIdentifiantRessourceOperationnelle/FHIR/TRE_R354-TypeIdentifiantRessourceOperationnelle
 Alias: $restful-security-service = http://terminology.hl7.org/CodeSystem/restful-security-service
+Alias: $TRE-R04-TypeSavoirFaire = https://mos.esante.gouv.fr/NOS/TRE_R04-TypeSavoirFaire/FHIR/TRE-R04-TypeSavoirFaire
 
 //JDV
 Alias: $JDV-J124-Commune = https://mos.esante.gouv.fr/NOS/JDV_J124-Commune/FHIR/JDV-J124-Commune // Solution temporaire en attendant de pouvoir utlisier le JDV IS fr-insee-code (package fr-core)

--- a/input/fsh/profiles/RORHealthcareService.fsh
+++ b/input/fsh/profiles/RORHealthcareService.fsh
@@ -142,16 +142,16 @@ Description: "Profil créé dans le cadre du ROR pour décrire les prestations q
 
 
 * specialty 1..* MS
-* specialty ^slicing.discriminator.type = #value 
-* specialty ^slicing.discriminator.path = "coding.system" 
-* specialty ^slicing.rules = #open
-* specialty contains
+* specialty.coding ^slicing.discriminator.type = #value 
+* specialty.coding ^slicing.discriminator.path = "system" 
+* specialty.coding ^slicing.rules = #open
+* specialty.coding contains
     operationalActivity 1..1 MS and
     operationalActivityFamily 0..1 MS
-* specialty[operationalActivity] ^short = "activiteOperationnelle (ActiviteOperationnelle) : ensemble cohérent d’actions et de pratiques mises en œuvre pour répondre aux besoins en Santé de la personne"
-* specialty[operationalActivity] from $JDV-J17-ActiviteOperationnelle-ROR
-* specialty[operationalActivityFamily] ^short = "familleActiviteOperationnelle (ActiviteOperationnelle) : regroupement cohérent d’activités délivrées dans le cadre d'une prestation, répondant à un besoin de la personne"
-* specialty[operationalActivityFamily] from $JDV-J51-FamilleActiviteOperationnelle-ROR
+* specialty.coding[operationalActivity] ^short = "activiteOperationnelle (ActiviteOperationnelle) : ensemble cohérent d’actions et de pratiques mises en œuvre pour répondre aux besoins en Santé de la personne"
+* specialty.coding[operationalActivity] from $JDV-J17-ActiviteOperationnelle-ROR
+* specialty.coding[operationalActivityFamily] ^short = "familleActiviteOperationnelle (ActiviteOperationnelle) : regroupement cohérent d’activités délivrées dans le cadre d'une prestation, répondant à un besoin de la personne"
+* specialty.coding[operationalActivityFamily] from $JDV-J51-FamilleActiviteOperationnelle-ROR
 
 * notAvailable MS
 * notAvailable ^slicing.discriminator.type = #value 

--- a/input/fsh/profiles/RORPractitionerRole.fsh
+++ b/input/fsh/profiles/RORPractitionerRole.fsh
@@ -67,7 +67,7 @@ Description: "Profil créé dans le cadre du ROR pour décrire les modalités d'
 * specialty.coding ^slicing.discriminator.path = "url"
 * specialty.coding ^slicing.rules = #open
 * specialty.coding contains
-    expertiseType 1..1 MS
+    expertiseType 0..1 MS
 * specialty.coding[expertiseType] ^short = "typeSavoirFaire (SavoirFaire) : Type de savoir-faire (qualifications/autres attributions)"
 * specialty.coding[expertiseType] from $JDV-J209-TypeSavoirFaire-ROR (required)
 * specialty ^slicing.discriminator.type = #value

--- a/input/fsh/profiles/RORPractitionerRole.fsh
+++ b/input/fsh/profiles/RORPractitionerRole.fsh
@@ -85,28 +85,28 @@ Description: "Profil créé dans le cadre du ROR pour décrire les modalités d'
     specificCompetence 0..* MS
 * specialty[specialty] ^short = "specialite (SavoirFaire) : Spécialité ordinale"
 * specialty[specialty] from $JDV-J210-SpecialiteOrdinale-ROR (required)
-* specialty[specialty].coding[expertiseType] = $JDV-J209-TypeSavoirFaire-ROR#S
+* specialty[specialty].coding[expertiseType] = $TRE-R04-TypeSavoirFaire#S
 * specialty[competence] ^short = "competence (SavoirFaire) : Compétence acquise par le professionnel"
 * specialty[competence] from $JDV-J232-Competence-ROR (required)
-* specialty[competence].coding[expertiseType] = $JDV-J209-TypeSavoirFaire-ROR#C
+* specialty[competence].coding[expertiseType] = $TRE-R04-TypeSavoirFaire#C
 * specialty[exclusiveCompetence] ^short = "competenceExclusive (SavoirFaire) : Compétence exclusive"
 * specialty[exclusiveCompetence] from $JDV-J211-CompetenceExclusive-ROR (required)
-* specialty[exclusiveCompetence].coding[expertiseType] = $JDV-J209-TypeSavoirFaire-ROR#CEX
+* specialty[exclusiveCompetence].coding[expertiseType] = $TRE-R04-TypeSavoirFaire#CEX
 * specialty[specificOrientation] ^short = "orientationParticuliere (SavoirFaire) : Orientation particulière"
 * specialty[specificOrientation] from $JDV-J212-OrientationParticuliere-ROR (required)
-* specialty[specificOrientation].coding[expertiseType] = $JDV-J209-TypeSavoirFaire-ROR#OP
+* specialty[specificOrientation].coding[expertiseType] = $TRE-R04-TypeSavoirFaire#OP
 * specialty[expertiseCapacity] ^short = "capacite (SavoirFaire) : Capacité de médecine"
 * specialty[expertiseCapacity] from $JDV-J213-CapaciteSavoirFaire-ROR (required)
-* specialty[expertiseCapacity].coding[expertiseType] = $JDV-J209-TypeSavoirFaire-ROR#CAPA
+* specialty[expertiseCapacity].coding[expertiseType] = $TRE-R04-TypeSavoirFaire#CAPA
 * specialty[qualificationPAC] ^short = "qualificationPAC (SavoirFaire) : Qualification de praticien adjoint contractuel"
 * specialty[qualificationPAC] from $JDV-J214-QualificationPAC-ROR (required)
-* specialty[qualificationPAC].coding[expertiseType] = $JDV-J209-TypeSavoirFaire-ROR#PAC
+* specialty[qualificationPAC].coding[expertiseType] = $TRE-R04-TypeSavoirFaire#PAC
 * specialty[nonQualifyingDESC] ^short = "DESCNonQualifiant (SavoirFaire) : Diplôme d'études spécialisées complémentaires (DESC)"
 * specialty[nonQualifyingDESC] from $JDV-J215-DESCnonQualifiant-ROR (required)
-* specialty[nonQualifyingDESC].coding[expertiseType] = $JDV-J209-TypeSavoirFaire-ROR#DNQ
+* specialty[nonQualifyingDESC].coding[expertiseType] = $TRE-R04-TypeSavoirFaire#DNQ
 * specialty[supplementaryExerciseRight] ^short = "droitExerciceComplémentaire (SavoirFaire) : Droit d'exercice complémentaire du professionnel"
 * specialty[supplementaryExerciseRight] from $JDV-J216-DroitExerciceCompl-ROR (required)
-* specialty[supplementaryExerciseRight].coding[expertiseType] = $JDV-J209-TypeSavoirFaire-ROR#DEC
+* specialty[supplementaryExerciseRight].coding[expertiseType] = $TRE-R04-TypeSavoirFaire#DEC
 * specialty[specificCompetence] ^short = "competenceSpecifique (SituationOperationnelle) : Capacité ou connaissance reconnue qui permet ou facilite l’accueil d’une personne"
 * specialty[specificCompetence] from $JDV-J33-CompetenceSpecifique-ROR (required)
 

--- a/input/fsh/profiles/RORPractitionerRole.fsh
+++ b/input/fsh/profiles/RORPractitionerRole.fsh
@@ -85,20 +85,28 @@ Description: "Profil créé dans le cadre du ROR pour décrire les modalités d'
     specificCompetence 0..* MS
 * specialty[specialty] ^short = "specialite (SavoirFaire) : Spécialité ordinale"
 * specialty[specialty] from $JDV-J210-SpecialiteOrdinale-ROR (required)
+* specialty[specialty].coding[expertiseType] = $JDV-J209-TypeSavoirFaire-ROR#S
 * specialty[competence] ^short = "competence (SavoirFaire) : Compétence acquise par le professionnel"
 * specialty[competence] from $JDV-J232-Competence-ROR (required)
+* specialty[competence].coding[expertiseType] = $JDV-J209-TypeSavoirFaire-ROR#C
 * specialty[exclusiveCompetence] ^short = "competenceExclusive (SavoirFaire) : Compétence exclusive"
 * specialty[exclusiveCompetence] from $JDV-J211-CompetenceExclusive-ROR (required)
+* specialty[exclusiveCompetence].coding[expertiseType] = $JDV-J209-TypeSavoirFaire-ROR#CEX
 * specialty[specificOrientation] ^short = "orientationParticuliere (SavoirFaire) : Orientation particulière"
 * specialty[specificOrientation] from $JDV-J212-OrientationParticuliere-ROR (required)
+* specialty[specificOrientation].coding[expertiseType] = $JDV-J209-TypeSavoirFaire-ROR#OP
 * specialty[expertiseCapacity] ^short = "capacite (SavoirFaire) : Capacité de médecine"
 * specialty[expertiseCapacity] from $JDV-J213-CapaciteSavoirFaire-ROR (required)
+* specialty[expertiseCapacity].coding[expertiseType] = $JDV-J209-TypeSavoirFaire-ROR#CAPA
 * specialty[qualificationPAC] ^short = "qualificationPAC (SavoirFaire) : Qualification de praticien adjoint contractuel"
 * specialty[qualificationPAC] from $JDV-J214-QualificationPAC-ROR (required)
+* specialty[qualificationPAC].coding[expertiseType] = $JDV-J209-TypeSavoirFaire-ROR#PAC
 * specialty[nonQualifyingDESC] ^short = "DESCNonQualifiant (SavoirFaire) : Diplôme d'études spécialisées complémentaires (DESC)"
 * specialty[nonQualifyingDESC] from $JDV-J215-DESCnonQualifiant-ROR (required)
+* specialty[nonQualifyingDESC].coding[expertiseType] = $JDV-J209-TypeSavoirFaire-ROR#DNQ
 * specialty[supplementaryExerciseRight] ^short = "droitExerciceComplémentaire (SavoirFaire) : Droit d'exercice complémentaire du professionnel"
 * specialty[supplementaryExerciseRight] from $JDV-J216-DroitExerciceCompl-ROR (required)
+* specialty[supplementaryExerciseRight].coding[expertiseType] = $JDV-J209-TypeSavoirFaire-ROR#DEC
 * specialty[specificCompetence] ^short = "competenceSpecifique (SituationOperationnelle) : Capacité ou connaissance reconnue qui permet ou facilite l’accueil d’une personne"
 * specialty[specificCompetence] from $JDV-J33-CompetenceSpecifique-ROR (required)
 

--- a/input/fsh/profiles/RORPractitionerRole.fsh
+++ b/input/fsh/profiles/RORPractitionerRole.fsh
@@ -63,11 +63,17 @@ Description: "Profil créé dans le cadre du ROR pour décrire les modalités d'
 * telecom.extension[ror-telecom-confidentiality-level] ^short = "niveauConfidentialite (Telecommunication) : niveau de restriction de l'accès aux attributs de la classe Télécommunication"
 
 * specialty 0..* MS
+* specialty.coding ^slicing.discriminator.type = #value
+* specialty.coding ^slicing.discriminator.path = "url"
+* specialty.coding ^slicing.rules = #open
+* specialty.coding contains
+    expertiseType 1..1 MS
+* specialty.coding[expertiseType] ^short = "typeSavoirFaire (SavoirFaire) : Type de savoir-faire (qualifications/autres attributions)"
+* specialty.coding[expertiseType] from $JDV-J209-TypeSavoirFaire-ROR (required)
 * specialty ^slicing.discriminator.type = #value
 * specialty ^slicing.discriminator.path = "url"
 * specialty ^slicing.rules = #open
 * specialty contains
-    expertiseType 1..1 MS and
     specialty 0..1 MS and
     competence 0..1 MS and
     exclusiveCompetence 0..1 MS and
@@ -77,8 +83,6 @@ Description: "Profil créé dans le cadre du ROR pour décrire les modalités d'
     nonQualifyingDESC 0..1 MS and
     supplementaryExerciseRight 0..1 MS and
     specificCompetence 0..* MS
-* specialty[expertiseType] ^short = "typeSavoirFaire (SavoirFaire) : Type de savoir-faire (qualifications/autres attributions)"
-* specialty[expertiseType] from $JDV-J209-TypeSavoirFaire-ROR (required)
 * specialty[specialty] ^short = "specialite (SavoirFaire) : Spécialité ordinale"
 * specialty[specialty] from $JDV-J210-SpecialiteOrdinale-ROR (required)
 * specialty[competence] ^short = "competence (SavoirFaire) : Compétence acquise par le professionnel"


### PR DESCRIPTION
## Description des changements

#308 Ajout d’un lien entre le type de savoir et le savoir-faire : 

Slice de l’élément coding du codeableConcept 

- Le premier slice de coding porte le type de savoir-faire. La cardinalité a été mise à 0..1 car le slice [specialty:specificCompetence](https://ansforge.github.io/IG-fhir-repertoire-offre-ressources-sante/main/ig/StructureDefinition-ror-practitionerrole-definitions.html#diff_PractitionerRole.specialty:specificCompetence) est lié à la situation opérationnelle et non à un savoir-faire. 
-> Une valeur issue du JDV_J209-TypeSavoirFaire-ROR a été fixée sur les slices de savoir-faire.

- Le deuxième slice de coding porte le JDV spécifié pour chaque savoir-faire


#222 Ajout d’un lien entre l’activité opérationnelle et la famille d’activité opérationnelle : 

Slice de l’élément coding du codeableConcept 

- operationalActivity [1..1] JDV_J17-ActiviteOperationnelle-ROR
- operationalActivityFamily [0..1] JDV_J51-FamilleActiviteOperationnelle-ROR


## Preview

RORPractitionerRole : https://ansforge.github.io/IG-fhir-repertoire-offre-ressources-sante/lien-specialty-slice-coding/ig/StructureDefinition-ror-practitionerrole.html

RORHealthcareService : https://ansforge.github.io/IG-fhir-repertoire-offre-ressources-sante/lien-specialty-slice-coding/ig/StructureDefinition-ror-healthcareservice.html

## Impact API ROR
