### PR TITLE
add snapshot-1

### DIFF
--- a/publication-request.json
+++ b/publication-request.json
@@ -1,10 +1,10 @@
 {
     "package-id" : "ans.fhir.fr.ror",
-    "version" : "0.4.0-qa-preview-1",
-    "path" : "https://interop.esante.gouv.fr/ig/fhir/ror/0.4.0-qa-preview-1",
+    "version" : "0.4.0-snapshot-1",
+    "path" : "https://interop.esante.gouv.fr/ig/fhir/ror/0.4.0-snapshot-1",
     "mode" : "working",
     "status" : "qa-preview",
     "sequence" : "trial-use",
-    "desc" : "Release 0.4.0 qa-preview-1 du guide d'Implémentation de l'API FHIR du ROR compatible avec le modèle d'exposition 3.0 du ROR et ayant pour cible l'implementation 3.2 du ROR National.",
+    "desc" : "Release 0.4.0 snapshot-1 du guide d'Implémentation de l'API FHIR du ROR compatible avec le modèle d'exposition 3.0 du ROR et ayant pour cible l'implementation 3.2 du ROR National.",
     "descmd" : "@[release-notes.md]"
 }

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,4 +1,4 @@
-#### Release 0.4.0-qa-preview-1 de l'Implementation Guide FHIR du ROR compatible avec le modèle d'exposition 3.0 du ROR et ayant pour cible l'implementation 3.2 du ROR National.
+#### Release 0.4.0-snapshot-1 de l'Implementation Guide FHIR du ROR compatible avec le modèle d'exposition 3.0 du ROR et ayant pour cible l'implementation 3.2 du ROR National.
 Cette version est à destination des développeurs de la solution ROR National et des recetteurs. Elle permet aussi d'apporter de l'information aux consommateurs concernant les nouveautés en cours d'implémentation.
 
 [Modifications apportées dans cette release](https://github.com/ansforge/IG-fhir-repertoire-offre-ressources-sante/milestone/5?closed=1) :

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -14,7 +14,7 @@ dependencies:
   hl7.fhir.uv.bulkdata: 2.0.0
   ans.fr.securisation-transport: 1.2.0
 status: draft
-version: 0.4.0-qa-preview-1
+version: 0.4.0-snapshot-1
 fhirVersion: 4.0.1
 copyrightYear: 2020+
 releaseLabel: qa-preview


### PR DESCRIPTION
remplace qa-review-1 dans la version

## Description des changements

changement du nom de la version en remplaçant qa-review-1 par snapshot-1
* ...

## Preview

https://ansforge.github.io/IG-fhir-repertoire-offre-ressources-sante/sd-update-conf-publication/ig/ pour prévisualiser l'IG d'une branche

## Impact API ROR
