### PR TITLE
mise à jour de la page consultation offre et le modifier _elements n'est pas implémenté

### DIFF
--- a/input/fsh/instances/ror-consommateur.fsh
+++ b/input/fsh/instances/ror-consommateur.fsh
@@ -39,6 +39,7 @@ Usage: #definition
 * rest.searchParam[=].type = #token
 * rest.searchParam[=].documentation = "Permet de choisir dans quel ordre renvoyer les résultats"
 
+// Implémentation probable sur la V5 du ROR
 //* rest.searchParam[+].name = "_elements"
 //* rest.searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-elements"
 //* rest.searchParam[=].type = #string

--- a/input/fsh/instances/ror-consommateur.fsh
+++ b/input/fsh/instances/ror-consommateur.fsh
@@ -39,10 +39,10 @@ Usage: #definition
 * rest.searchParam[=].type = #token
 * rest.searchParam[=].documentation = "Permet de choisir dans quel ordre renvoyer les résultats"
 
-* rest.searchParam[+].name = "_elements"
-* rest.searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-elements"
-* rest.searchParam[=].type = #string
-* rest.searchParam[=].documentation = "Permet au consommateur de demander les éléments à retourner de la ressource recherchée"
+//* rest.searchParam[+].name = "_elements"
+//* rest.searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-elements"
+//* rest.searchParam[=].type = #string
+//* rest.searchParam[=].documentation = "Permet au consommateur de demander les éléments à retourner de la ressource recherchée"
 
 * rest.searchParam[+].name = "_include"
 * rest.searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-include"

--- a/input/fsh/instances/ror-serveur.fsh
+++ b/input/fsh/instances/ror-serveur.fsh
@@ -39,6 +39,7 @@ Usage: #definition
 * rest.searchParam[=].type = #token
 * rest.searchParam[=].documentation = "Permet de choisir dans quel ordre renvoyer les résultats"
 
+//Implémentation probable en V5
 //* rest.searchParam[+].name = "_elements"
 //* rest.searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-elements"
 //* rest.searchParam[=].type = #string

--- a/input/fsh/instances/ror-serveur.fsh
+++ b/input/fsh/instances/ror-serveur.fsh
@@ -39,10 +39,10 @@ Usage: #definition
 * rest.searchParam[=].type = #token
 * rest.searchParam[=].documentation = "Permet de choisir dans quel ordre renvoyer les résultats"
 
-* rest.searchParam[+].name = "_elements"
-* rest.searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-elements"
-* rest.searchParam[=].type = #string
-* rest.searchParam[=].documentation = "Permet au consommateur de demander les éléments à retourner de la ressource recherchée"
+//* rest.searchParam[+].name = "_elements"
+//* rest.searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-elements"
+//* rest.searchParam[=].type = #string
+//* rest.searchParam[=].documentation = "Permet au consommateur de demander les éléments à retourner de la ressource recherchée"
 
 * rest.searchParam[+].name = "_include"
 * rest.searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-include"

--- a/input/pagecontent/modifiers.md
+++ b/input/pagecontent/modifiers.md
@@ -159,7 +159,7 @@
   mso-border-bottom-alt:solid #8EAADB .5pt;padding:0cm 5.4pt 0cm 5.4pt'>
   <p class=MsoNormal align=left style='text-align:left;mso-yfti-cnfc:4'><b><span
   style='font-size:9.0pt;mso-bidi-font-size:10.0pt;line-height:115%'>_<span
-  class=SpellE>elements</span><o:p></o:p></span></b></p>
+  class=SpellE>elements</span><code><span style="color: #ff0000;">draft</span></code><o:p></o:p></span></b></p>
   </td>
   <td width="38%" colspan=2 style='width:38.92%;border:none;border-bottom:solid #8EAADB 1.0pt;
   mso-border-top-alt:solid #8EAADB .5pt;mso-border-top-alt:solid #8EAADB .5pt;

--- a/input/pagecontent/specifications_techniques_2.md
+++ b/input/pagecontent/specifications_techniques_2.md
@@ -180,6 +180,7 @@ Plus d'information ici : <http://hl7.org/fhir/R4/async.html#3.1.6.4>
 Pour réaliser cette opération nous utilisons http://hl7.org/fhir/uv/bulkdata/STU2/export.html
 
 **Requête :**
+
 **N.B.: Dans le Header il est nécessaire de préciser:**
 `--header 'Prefer: respond-async'`\
 Plus d'information ici : <http://hl7.org/fhir/R4/async.html>

--- a/input/pagecontent/specifications_techniques_2.md
+++ b/input/pagecontent/specifications_techniques_2.md
@@ -204,7 +204,7 @@ Exemple :
 `[BASE]/$export-poll-status?_jobId=990789c0-f170-400f-97dd-ed2ac6fd22dc`
 Plus d'information ici : <http://hl7.org/fhir/R4/async.html#3.1.6.4>
 
-#### Scénario 2 : Extraction de l’ensemble des offres de santé d’un établissement
+#### Scénario 2 : Extraction de l’ensemble des offres de santé d’un établissement <code><span style="color: #ff0000;">draft</span></code>
 
 **Description du scénario :** un consommateur souhaite rechercher l\'offre de santé proposée\ par un établissement dont l'identifiant est = XX .
 

--- a/input/pagecontent/specifications_techniques_2.md
+++ b/input/pagecontent/specifications_techniques_2.md
@@ -130,7 +130,7 @@ GET [BASE]/HealthcareService?
 #### Scénario 1 bis : Extraction complète asynchrone <code><span style="color: #ff0000;">draft</span></code>
 
 <p style="background-color: #ffcccc; border:1px solid grey; padding: 5px; max-width: 790px;">
-<b>Note importante:</b> Ce scénario est implémenté dans la version actuelle du ROR mais nous le maintenons à l'état draft car il ne respecte pas les points suivants de la spécification du bulkdata <a>https://hl7.org/fhir/uv/bulkdata/export.html</a> : <br>
+<b>Note importante:</b> Cette fonctionnalité est implémentée dans la version actuelle du ROR mais nous le maintenons à l'état draft car elle ne respecte pas les points suivants de la spécification du bulkdata <a>https://hl7.org/fhir/uv/bulkdata/export.html</a> : <br>
 - le paramètre <code>_outputFormat</code> ne supporte pas <code>application/fhir+ndjson</code>, les valeurs possibles sont <code>application/fhir+json</code> ou <code>application/json</code><br>
 - le header <code>'Prefer: respond-async'</code> n'est pas obligatoire<br>
 - que le paramètre <code>includeAssociatedData=_myCompleteExtract</code> soit présent ou non, l'export retourne toujours l'ensemble complet des ressources FHIR en lien avec la ressource HealthcareService

--- a/input/pagecontent/specifications_techniques_2.md
+++ b/input/pagecontent/specifications_techniques_2.md
@@ -170,7 +170,7 @@ Plus d'information ici : <http://hl7.org/fhir/R4/async.html#3.1.6.4>
 #### Scénario 1 ter : Extraction complète asynchrone par région <code><span style="color: #ff0000;">draft</span></code>
 
 <p style="background-color: #ffcccc; border:1px solid grey; padding: 5px; max-width: 790px;">
-<b>Note importante:</b> Ce scénario est implémenté dans la version actuelle du ROR mais nous le maintenons à l'état draft car il ne respecte pas les points suivants de la spécification du bulkdata <a>https://hl7.org/fhir/uv/bulkdata/export.html</a><br>
+<b>Note importante:</b> Cette fonctionnalité est implémentée dans la version actuelle du ROR mais nous le maintenons à l'état draft car elle ne respecte pas les points suivants de la spécification du bulkdata <a>https://hl7.org/fhir/uv/bulkdata/export.html</a><br>
 - le paramètre <code>_outputFormat</code> ne supporte pas <code>application/fhir+ndjson</code>, les valeurs possibles sont <code>application/fhir+json</code> ou <code>application/json</code><br>
 - le header <code>'Prefer: respond-async'</code> n'est pas obligatoire<br>
 - que le paramètre <code>includeAssociatedData=_myCompleteExtract</code> soit présent ou non, l'export retourne toujours l'ensemble prédéfini des ressources FHIR définies

--- a/input/pagecontent/specifications_techniques_2.md
+++ b/input/pagecontent/specifications_techniques_2.md
@@ -106,7 +106,9 @@ Les paramètres et modificateurs de requêtes sont décrits [ici](modifiers.html
 
 **Description du scénario :** Un consommateur souhaite mettre à jour toutes les offres de santé sur le périmètre national.
 
-**Avertissement:** Ce scénario est déprécié et ne doit pas être utilisé car il ne retournera pas l'intégralité de l'extraction.
+<p style="background-color: #ffcccc; border:1px solid grey; padding: 5px; max-width: 790px;">
+<b>Avertissement:</b> Ce scénario est déprécié et ne doit pas être utilisé car il ne retournera pas l'intégralité de l'extraction.
+</p>
 
 **Requête :**
 
@@ -127,10 +129,12 @@ GET [BASE]/HealthcareService?
 
 #### Scénario 1 bis : Extraction complète asynchrone <code><span style="color: #ff0000;">draft</span></code>
 
-**Note importante:** Ce scénario est implémenté dans la version actuelle du ROR mais nous le maintenons à l'état draft car dans l'implémentation :
-- le paramètre *_outputFormat* ne supporte pas *application/fhir+ndjson*, les valeurs possibles sont *application/fhir+json* ou *application/json*
-- le header *'Prefer: respond-async'* n'est pas obligatoire
-- que le paramètre *includeAssociatedData=_myCompleteExtract* soit présent ou non, l'export retourne toujours l'ensemble prédéfini des ressources FHIR définies
+<p style="background-color: #ffcccc; border:1px solid grey; padding: 5px; max-width: 790px;">
+<b>Note importante:</b> Ce scénario est implémenté dans la version actuelle du ROR mais nous le maintenons à l'état draft car dans l'implémentation :<br>
+- le paramètre <i>_outputFormat</i> ne supporte pas <i>application/fhir+ndjson</i>, les valeurs possibles sont <i>application/fhir+json</i> ou <i>application/json</i><br>
+- le header <i>'Prefer: respond-async'</i> n'est pas obligatoire<br>
+- que le paramètre <i>includeAssociatedData=_myCompleteExtract</i> soit présent ou non, l'export retourne toujours l'ensemble complet des ressources FHIR en lien avec la ressource HealthcareService
+</p>
 
 **Description du scénario :** Un consommateur souhaite mettre à jour toutes les offres de santé sur le périmètre national de manière asynchrone (pour une question de performance et de volumétrie). Il réalise donc une extraction complète de l'offre nationale.
 Pour réaliser cette opération nous utilisons http://hl7.org/fhir/uv/bulkdata/STU2/export.html
@@ -165,10 +169,12 @@ Plus d'information ici : <http://hl7.org/fhir/R4/async.html#3.1.6.4>
 
 #### Scénario 1 ter : Extraction complète asynchrone par région <code><span style="color: #ff0000;">draft</span></code>
 
-**Note importante:** Ce scénario est implémenté dans la version actuelle du ROR mais nous le maintenons à l'état draft car dans l'implémentation :
-- le paramètre *_outputFormat* ne supporte pas *application/fhir+ndjson*, les valeurs possibles sont *application/fhir+json* ou *application/json*
-- le header *'Prefer: respond-async'* n'est pas obligatoire
-- que le paramètre *includeAssociatedData=_myCompleteExtract* soit présent ou non, l'export retourne toujours l'ensemble prédéfini des ressources FHIR définies
+<p style="background-color: #ffcccc; border:1px solid grey; padding: 5px; max-width: 790px;">
+<b>Note importante:</b> Ce scénario est implémenté dans la version actuelle du ROR mais nous le maintenons à l'état draft car dans l'implémentation :<br>
+- le paramètre <i>_outputFormat</i> ne supporte pas <i>application/fhir+ndjson</i>, les valeurs possibles sont <i>application/fhir+json</i> ou <i>application/json</i><br>
+- le header <i>'Prefer: respond-async'</i> n'est pas obligatoire<br>
+- que le paramètre <i>includeAssociatedData=_myCompleteExtract</i> soit présent ou non, l'export retourne toujours l'ensemble prédéfini des ressources FHIR définies
+</p>
 
 **Description du scénario :** Un consommateur souhaite mettre à jour toutes les offres de santé sur un périmètre régional de manière asynchrone (pour une question de performance et de volumétrie). Il réalise donc une extraction complète de l'offre régionale.
 Pour réaliser cette opération nous utilisons http://hl7.org/fhir/uv/bulkdata/STU2/export.html

--- a/input/pagecontent/specifications_techniques_2.md
+++ b/input/pagecontent/specifications_techniques_2.md
@@ -130,7 +130,7 @@ GET [BASE]/HealthcareService?
 #### Scénario 1 bis : Extraction complète asynchrone <code><span style="color: #ff0000;">draft</span></code>
 
 <p style="background-color: #ffcccc; border:1px solid grey; padding: 5px; max-width: 790px;">
-<b>Note importante:</b> Ce scénario est implémenté dans la version actuelle du ROR mais nous le maintenons à l'état draft car dans l'implémentation :<br>
+<b>Note importante:</b> Ce scénario est implémenté dans la version actuelle du ROR mais nous le maintenons à l'état draft car il ne respecte pas les points suivants de la spécification du bulkdata <a>https://hl7.org/fhir/uv/bulkdata/export.html</a> : <br>
 - le paramètre <i>_outputFormat</i> ne supporte pas <i>application/fhir+ndjson</i>, les valeurs possibles sont <i>application/fhir+json</i> ou <i>application/json</i><br>
 - le header <i>'Prefer: respond-async'</i> n'est pas obligatoire<br>
 - que le paramètre <i>includeAssociatedData=_myCompleteExtract</i> soit présent ou non, l'export retourne toujours l'ensemble complet des ressources FHIR en lien avec la ressource HealthcareService
@@ -170,7 +170,7 @@ Plus d'information ici : <http://hl7.org/fhir/R4/async.html#3.1.6.4>
 #### Scénario 1 ter : Extraction complète asynchrone par région <code><span style="color: #ff0000;">draft</span></code>
 
 <p style="background-color: #ffcccc; border:1px solid grey; padding: 5px; max-width: 790px;">
-<b>Note importante:</b> Ce scénario est implémenté dans la version actuelle du ROR mais nous le maintenons à l'état draft car dans l'implémentation :<br>
+<b>Note importante:</b> Ce scénario est implémenté dans la version actuelle du ROR mais nous le maintenons à l'état draft car il ne respecte pas les points suivants de la spécification du bulkdata <a>https://hl7.org/fhir/uv/bulkdata/export.html</a><br>
 - le paramètre <i>_outputFormat</i> ne supporte pas <i>application/fhir+ndjson</i>, les valeurs possibles sont <i>application/fhir+json</i> ou <i>application/json</i><br>
 - le header <i>'Prefer: respond-async'</i> n'est pas obligatoire<br>
 - que le paramètre <i>includeAssociatedData=_myCompleteExtract</i> soit présent ou non, l'export retourne toujours l'ensemble prédéfini des ressources FHIR définies

--- a/input/pagecontent/specifications_techniques_2.md
+++ b/input/pagecontent/specifications_techniques_2.md
@@ -131,9 +131,9 @@ GET [BASE]/HealthcareService?
 
 <p style="background-color: #ffcccc; border:1px solid grey; padding: 5px; max-width: 790px;">
 <b>Note importante:</b> Ce scénario est implémenté dans la version actuelle du ROR mais nous le maintenons à l'état draft car il ne respecte pas les points suivants de la spécification du bulkdata <a>https://hl7.org/fhir/uv/bulkdata/export.html</a> : <br>
-- le paramètre <i>_outputFormat</i> ne supporte pas <i>application/fhir+ndjson</i>, les valeurs possibles sont <i>application/fhir+json</i> ou <i>application/json</i><br>
-- le header <i>'Prefer: respond-async'</i> n'est pas obligatoire<br>
-- que le paramètre <i>includeAssociatedData=_myCompleteExtract</i> soit présent ou non, l'export retourne toujours l'ensemble complet des ressources FHIR en lien avec la ressource HealthcareService
+- le paramètre <code>_outputFormat</code> ne supporte pas <code>application/fhir+ndjson</code>, les valeurs possibles sont <code>application/fhir+json</code> ou <code>application/json</code><br>
+- le header <code>'Prefer: respond-async'</code> n'est pas obligatoire<br>
+- que le paramètre <code>includeAssociatedData=_myCompleteExtract</code> soit présent ou non, l'export retourne toujours l'ensemble complet des ressources FHIR en lien avec la ressource HealthcareService
 </p>
 
 **Description du scénario :** Un consommateur souhaite mettre à jour toutes les offres de santé sur le périmètre national de manière asynchrone (pour une question de performance et de volumétrie). Il réalise donc une extraction complète de l'offre nationale.
@@ -171,9 +171,9 @@ Plus d'information ici : <http://hl7.org/fhir/R4/async.html#3.1.6.4>
 
 <p style="background-color: #ffcccc; border:1px solid grey; padding: 5px; max-width: 790px;">
 <b>Note importante:</b> Ce scénario est implémenté dans la version actuelle du ROR mais nous le maintenons à l'état draft car il ne respecte pas les points suivants de la spécification du bulkdata <a>https://hl7.org/fhir/uv/bulkdata/export.html</a><br>
-- le paramètre <i>_outputFormat</i> ne supporte pas <i>application/fhir+ndjson</i>, les valeurs possibles sont <i>application/fhir+json</i> ou <i>application/json</i><br>
-- le header <i>'Prefer: respond-async'</i> n'est pas obligatoire<br>
-- que le paramètre <i>includeAssociatedData=_myCompleteExtract</i> soit présent ou non, l'export retourne toujours l'ensemble prédéfini des ressources FHIR définies
+- le paramètre <code>_outputFormat</code> ne supporte pas <code>application/fhir+ndjson</code>, les valeurs possibles sont <code>application/fhir+json</code> ou <code>application/json</code><br>
+- le header <code>'Prefer: respond-async'</code> n'est pas obligatoire<br>
+- que le paramètre <code>includeAssociatedData=_myCompleteExtract</code> soit présent ou non, l'export retourne toujours l'ensemble prédéfini des ressources FHIR définies
 </p>
 
 **Description du scénario :** Un consommateur souhaite mettre à jour toutes les offres de santé sur un périmètre régional de manière asynchrone (pour une question de performance et de volumétrie). Il réalise donc une extraction complète de l'offre régionale.

--- a/input/pagecontent/specifications_techniques_2.md
+++ b/input/pagecontent/specifications_techniques_2.md
@@ -106,6 +106,8 @@ Les paramètres et modificateurs de requêtes sont décrits [ici](modifiers.html
 
 **Description du scénario :** Un consommateur souhaite mettre à jour toutes les offres de santé sur le périmètre national.
 
+**Avertissement:** Ce scénario est déprécié et ne doit pas être utilisé car il ne retournera pas l'intégralité de l'extraction.
+
 **Requête :**
 
 ```
@@ -125,12 +127,18 @@ GET [BASE]/HealthcareService?
 
 #### Scénario 1 bis : Extraction complète asynchrone <code><span style="color: #ff0000;">draft</span></code>
 
+**Note importante:** Ce scénario est implémenté dans la version actuelle du ROR mais nous le maintenons à l'état draft car dans l'implémentation :
+- le paramètre *_outputFormat* ne supporte pas *application/fhir+ndjson*, les valeurs possibles sont *application/fhir+json* ou *application/json*
+- le header *'Prefer: respond-async'* n'est pas obligatoire
+- que le paramètre *includeAssociatedData=_myCompleteExtract* soit présent ou non, l'export retourne toujours l'ensemble prédéfini des ressources FHIR définies
+
 **Description du scénario :** Un consommateur souhaite mettre à jour toutes les offres de santé sur le périmètre national de manière asynchrone (pour une question de performance et de volumétrie). Il réalise donc une extraction complète de l'offre nationale.
 Pour réaliser cette opération nous utilisons http://hl7.org/fhir/uv/bulkdata/STU2/export.html
 
 **Requête :**
-**N.B.: Dans le Header il est nécessaire de préciser: **
-`--header 'Prefer: respond-async'`
+
+**N.B.: Dans le Header il est nécessaire de préciser**
+`--header 'Prefer: respond-async'`\
 Plus d'information ici : <http://hl7.org/fhir/R4/async.html>
 
 ```
@@ -153,14 +161,21 @@ Exemple :
 `[BASE]/$export-poll-status?_jobId=990789c0-f170-400f-97dd-ed2ac6fd22dc`
 Plus d'information ici : <http://hl7.org/fhir/R4/async.html#3.1.6.4>
 
+
+
 #### Scénario 1 ter : Extraction complète asynchrone par région <code><span style="color: #ff0000;">draft</span></code>
+
+**Note importante:** Ce scénario est implémenté dans la version actuelle du ROR mais nous le maintenons à l'état draft car dans l'implémentation :
+- le paramètre *_outputFormat* ne supporte pas *application/fhir+ndjson*, les valeurs possibles sont *application/fhir+json* ou *application/json*
+- le header *'Prefer: respond-async'* n'est pas obligatoire
+- que le paramètre *includeAssociatedData=_myCompleteExtract* soit présent ou non, l'export retourne toujours l'ensemble prédéfini des ressources FHIR définies
 
 **Description du scénario :** Un consommateur souhaite mettre à jour toutes les offres de santé sur un périmètre régional de manière asynchrone (pour une question de performance et de volumétrie). Il réalise donc une extraction complète de l'offre régionale.
 Pour réaliser cette opération nous utilisons http://hl7.org/fhir/uv/bulkdata/STU2/export.html
 
 **Requête :**
-**N.B.: Dans le Header il est nécessaire de préciser: **
-`--header 'Prefer: respond-async'`
+**N.B.: Dans le Header il est nécessaire de préciser:**
+`--header 'Prefer: respond-async'`\
 Plus d'information ici : <http://hl7.org/fhir/R4/async.html>
 
 ```
@@ -182,7 +197,7 @@ Exemple :
 `[BASE]/$export-poll-status?_jobId=990789c0-f170-400f-97dd-ed2ac6fd22dc`
 Plus d'information ici : <http://hl7.org/fhir/R4/async.html#3.1.6.4>
 
-#### Scénario 2 : Extraction de l’ensemble des offres de santé d’un établissement <code><span style="color: #ff0000;">draft</span></code>
+#### Scénario 2 : Extraction de l’ensemble des offres de santé d’un établissement
 
 **Description du scénario :** un consommateur souhaite rechercher l\'offre de santé proposée\ par un établissement dont l'identifiant est = XX .
 
@@ -204,7 +219,7 @@ GET [BASE]/HealthcareService?organization.identifier:above=XX #critère de reche
 
 ```
 
-#### Scénario 3 : Extraction d'une offre de santé identifiée <code><span style="color: #ff0000;">draft</span></code>
+#### Scénario 3 : Extraction d'une offre de santé identifiée
 
 **Description du scénario :** un consommateur souhaite
 rechercher une offre de santé\
@@ -226,7 +241,7 @@ GET [BASE]/HealthcareService?identifier=XXX #critère de recherche de l’identi
 &_revinclude=PractitionerRole:service #inclus les PractitionerRole qui référencent le HealthcareService
 &_include=PractitionerRole:practitioner #inclus les Practitioner référencés par PractitionerRole
 ```
-#### Scénario 4 : Extraction complète à partir d'une date de mise à jour de l'offre opérationnelle <code><span style="color: #ff0000;">draft</span></code>
+#### Scénario 4 : Extraction complète à partir d'une date de mise à jour de l'offre opérationnelle
 
 **Description du scénario :** Un consommateur souhaite mettre
 à jour toute l\'offre\
@@ -315,7 +330,7 @@ GET [BASE]/HealthcareService?_tag=https://mos.esante.gouv.fr/NOS/TRE_R30-RegionO
 Cette partie de la spécification est en cours de construction.
 </p>
 
-**Description du scénario :**un consommateur souhaite rechercher une offre de santé à partir de son identifiant = XXX et consulter les anomalies associées si elles existent.
+**Description du scénario :** un consommateur souhaite rechercher une offre de santé à partir de son identifiant = XXX et consulter les anomalies associées si elles existent.
 
 **Requête :**
 


### PR DESCRIPTION
Closes #414 

## Description des changements

*mise à jour de specifications_techniques_2.md : Scénario 1: ajout d'un avertissement
*mise à jour de specifications_techniques_2.md : Scénarios 1bis et 1ter: ajout d'une note importante
*mise à jour de specifications_techniques_2.md : Scénarios 2, 3 et 4: suppression du label "draft"
*_elements n'est pas implémenté: mise à jour des CS Server et Client ainsi que de la page modifiers.md



## Preview

https://ansforge.github.io/IG-fhir-repertoire-offre-ressources-sante/cp-consultation-offre/ig pour prévisualiser l'IG d'une branche

## Impact API ROR

Pas d'impact, il s'agit d'éléments déjà implémentés en 4.1 ou antérieur
