### PR TITLE
ajout d'une note cardinalité EG-OI, exercice professionnel-situations…

### DIFF
--- a/input/pagecontent/mapping.md
+++ b/input/pagecontent/mapping.md
@@ -13,7 +13,7 @@ Le fichier définissant le mapping FHIR pour le modèle d'exposition 3.0 du ROR 
 <div style="background-color: #ffcccc; border:1px solid grey; padding: 5px; max-width: 790px;">
 <b>Notes:</b>
     <ol>
-        <li>Dans l'implémentation actuelle du ROR, une <i>organisation interne (OI)</i> ne peut être rattachée qu'à une <i>entité géographique (EG)</i>, par exemple un pôle ne peut être rattaché qu'à une EG;</li>
+        <li>Dans l'implémentation actuelle du ROR, une <i>organisation interne (OI)</i> ne peut être rattachée qu'à une <i>entité géographique (EG)</i>, par exemple un pôle ne peut être rattaché qu'à une EG. Concernant les pôles multi-sites, une copie du pôle est créée pour chaque EG. Ce point est en cours d'étude pour améliorer ce fonctionnement dans une version prochaine du ROR;</li>
         <li><code>PractitionerRole</code> contient l'<i>exercice professionnel</i> et la <i>situation opérationnelle</i>. Dans le cas ou l'<i>exercice professionnel</i> est rattaché à plusieurs <i>situations opérationnelles</i>, alors il aura autant d'instance <code>PractitionerRole</code> qu'il y a de <i>situations opérationnelles</i> (les attributs de l'<i>exercice professionnel</i> sont dupliqués dans chacune de ces ressources);</li>
         <li>La cardinalité implémentée d'une instance de <code>Location</code> référencée dans une instance <code>HealthcareService</code> est 0..* au lieu de 1..*. Cela est dû à la temporalité de la création d'une instance <code>HealthcareService</code>, créée avant que les lieux de réalisation de l'offre (les instances <code>Location</code>) rattachés à l'offre ne soient connus.</li>
     </ol>


### PR DESCRIPTION
… opérationnelles, healthcareservice-location

## Description des changements

Ajout d'une note contenant : 
- Dans l'implémentation actuelle du ROR, une organisation interne ne peut être rattachée qu'à une entité géographique, par exemple un pôle ne peut être rattaché qu'à une EG;
- PractitionerRole contient l'exercice professionnel et la situation opérationnelle. Dans le cas ou l'exercice professionnel est rattaché à plusieurs situations opérationnelles, alors il aura autant de ressources PractitionerRole qu'il y a de situations opérationnelles (les attributs de l'exercice professionnel sont dupliqués dans chacune de ces ressources); 
- La cardinalité implémentée d'une Location d'un HealthcareService est 0..* au lieu de 1..*. Cela est dû à la temporalité de la création d'un HealthcareService, celui-ci est créé avant d'en connaitre les locations rattachées.

## Preview

https://ansforge.github.io/IG-fhir-repertoire-offre-ressources-sante/cp/maj-mapping-global/ig pour prévisualiser l'IG d'une branche

## Impact API ROR
