### PR TITLE
Fix short Organization.extension:organization-period

### DIFF
--- a/input/fsh/profiles/ROROrganization.fsh
+++ b/input/fsh/profiles/ROROrganization.fsh
@@ -206,7 +206,7 @@ Description: "Profil créé dans le cadre du ROR pour décrire les organismes du
 * extension[ror-organization-reopening-date] ^short = "datePrevisionnelleReouverture (OI) : Date prévisionnelle à partir de laquelle la prestation sera de nouveau assurée"
 * extension[ror-organization-creation-date] ^short = "dateCreation (EJ) : Date de création de l'entité juridique"
 * extension[ror-organization-closing-type] ^short = "typeFermeture (EJ + EG + OI) : Le type de fermeture d'un niveau organisationnel indique la temporalité de la fermeture."
-* extension[organization-period] ^short = "dateOuverture (EJ + OI) + dateFermeture (EJ + EG + OI)"
+* extension[organization-period] ^short = "dateOuverture (EG + OI) + dateFermeture (EJ + EG + OI)"
 * extension[ror-meta-comment] ^short = "commentaire (Metadonnee)"
 * extension[ror-meta-creation-date] ^short = "dateCreation (Metadonnee)"
 * extension[ror-organization-comment] ^short = "commentaire (EG) : Commentaire qui permet à la structure de donner des informations complémentaires"


### PR DESCRIPTION
Bonjour,

Dans le MEV3 il semblerait que la dateOuverture ne concerne pas l'Entité Juridique mais l'Entité Géographique et l'Organisation Interne.

<img width="547" height="416" alt="image" src="https://github.com/user-attachments/assets/43027226-7e96-41c9-b9aa-b8bc9b757e60" />

<img width="695" height="240" alt="image" src="https://github.com/user-attachments/assets/0d8bb171-bc73-4ba3-b6d2-d228c630bd93" />

https://interop.esante.gouv.fr/ig/fhir/ror/StructureDefinition-ror-organization-definitions.html#diff_Organization.extension:organization-period

Merci pour votre aide,

Nathan
Développeur sur le projet du ROR-National.