### PR TITLE
[CP]: Fix cardinalité 1..1 pour HealthcareService & Organization

### DIFF
--- a/input/fsh/profiles/RORHealthcareService.fsh
+++ b/input/fsh/profiles/RORHealthcareService.fsh
@@ -18,8 +18,8 @@ Description: "Profil créé dans le cadre du ROR pour décrire les prestations q
 * identifier 1..1 MS
 * identifier ^short = "identifiantOffre (OffreOperationnelle) : Identifiant de l'offre, unique et persistant au niveau national"
 * name ^short = "nomOffre (OffreOpérationnelle) : Dénomination sous laquelle l'offre est identifiée par le porteur d'offre"
-* name MS
-* providedBy MS
+* name 1..1 MS
+* providedBy 1..1 MS
 * providedBy only Reference(fr-organization or ROROrganization)
 * location MS
 * category 0..1 MS

--- a/input/fsh/profiles/ROROrganization.fsh
+++ b/input/fsh/profiles/ROROrganization.fsh
@@ -107,7 +107,7 @@ Description: "Profil créé dans le cadre du ROR pour décrire les organismes du
 * contact.extension contains
     RORContactFunctionContact named ror-contact-function-contact 0..1 MS and
     RORContactDescription named ror-contact-description 0..1 MS and
-    RORContactConfidentialityLevel named ror-contact-confidentiality-level 0..1 MS
+    RORContactConfidentialityLevel named ror-contact-confidentiality-level 1..1 MS
 * contact.extension[ror-contact-function-contact] ^short = "fonctionContact (Contact) : Un titre, une position ou une fonction de la personne assurant le contact au sein de l'organisation"
 * contact.extension[ror-contact-description] ^short = "description (Contact) : Une description du contact"
 * contact.extension[ror-contact-confidentiality-level] ^short = "niveauConfidentialite (Contact) : Niveau de restriction de l'accès aux attributs de la classe Contact"


### PR DESCRIPTION
## Description des changements

[HealthcareService.providedBy](https://ansforge.github.io/IG-fhir-repertoire-offre-ressources-sante/main/ig/StructureDefinition-ror-healthcareservice-definitions.html#key_HealthcareService.providedBy) 0..1 -> 1..1 :
Pour ne pas avoir d'HealthcareService orphelin (chaque OffreOperationnelle du MEV3 doit avoir une EG ou une OI parente)

[HealthcareService.name](https://ansforge.github.io/IG-fhir-repertoire-offre-ressources-sante/main/ig/StructureDefinition-ror-healthcareservice-definitions.html#key_HealthcareService.name) 0..1 -> 1..1

[Organization.contact.extension:ror-contact-confidentiality-level](https://ansforge.github.io/IG-fhir-repertoire-offre-ressources-sante/main/ig/StructureDefinition-ror-organization-definitions.html#key_Organization.contact.extension:ror-contact-confidentiality-level) 0..1 -> 1..1 :
Dans le MEV3 la classe contact.niveauConfidentialite est 1..1

<img width="800" height="324" alt="image" src="https://github.com/user-attachments/assets/a845c528-5b9a-4bae-95a1-b4d456333209" />

## Preview

https://ansforge.github.io/IG-fhir-repertoire-offre-ressources-sante/[nom_de_la_branche]/ig pour prévisualiser l'IG d'une branche

## Impact API ROR
Dans ROR-860
