### PR TITLE
fix/411 restriction status questionnaire

### DIFF
--- a/input/fsh/profiles/RORQuestionnaire.fsh
+++ b/input/fsh/profiles/RORQuestionnaire.fsh
@@ -26,7 +26,8 @@ https://hl7.org/fhir/uv/sdc/examples.html#using-itempopulationcontext-and-itemex
 * identifier ^short = "Identifiant du modèle de saisie. Exemple MS-141"
 * version ^short = "version du modèle de saisie"
 * version MS
-* status ^short = "Statut du modèle"
+* status from RORQuestionnaireStatusVS (required)
+* status ^short = "Statut du modèle (draft | active | retired)"
 * name 1..1 MS
 * name ^short = "Nom utilisé par les systèmes pour référencer le modèle Exemple MS-141"
 * title 1..1 MS

--- a/input/fsh/valueset/RORQuestionnaireStatusVS.fsh
+++ b/input/fsh/valueset/RORQuestionnaireStatusVS.fsh
@@ -1,0 +1,9 @@
+ValueSet: RORQuestionnaireStatusVS
+Id: ror-questionnaire-status-vs
+Title: "Statuts autorisés pour les Questionnaires ROR"
+Description: "Restriction des statuts de publication FHIR aux valeurs applicables aux modèles de saisie ROR. La valeur 'unknown' est exclue."
+* ^meta.profile = "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
+* ^experimental = true
+* http://hl7.org/fhir/publication-status#draft
+* http://hl7.org/fhir/publication-status#active
+* http://hl7.org/fhir/publication-status#retired


### PR DESCRIPTION
## Description des changements

* Ajout du ValueSet RORQuestionnaireStatusVS restreignant les statuts de publication FHIR aux valeurs applicables aux modèles de saisie ROR : draft, active et retired. La valeur unknown est exclue.
* RORQuestionnaire : ajout dun binding required sur status vers RORQuestionnaireStatusVS

## Preview

https://ansforge.github.io/IG-fhir-repertoire-offre-ressources-sante/sg/411-restriction-status-questionnaire/ig pour prévisualiser l'IG d'une branche

## Impact API ROR

pas d'impact
