### PR TITLE
Passage au template 2 et ajout du workflow clean-gh-pages

### DIFF
--- a/.github/workflows/clean-gh-pages.yml
+++ b/.github/workflows/clean-gh-pages.yml
@@ -1,0 +1,92 @@
+name: Clean gh-pages (remove stale branch deployments)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  clean-gh-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Remove stale branch deployments
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+
+          # Folders that are never deleted regardless of activity
+          PROTECTED="main"
+
+          CUTOFF_TS=$(date -d "30 days ago" +%s)
+          DELETED=0
+
+          # Collect branches with an open PR (up to 100)
+          OPEN_PR_BRANCHES=$(gh api "repos/$REPO/pulls?state=open&per_page=100" -q '.[].head.ref' 2>/dev/null || true)
+
+          for dir in */; do
+            dir="${dir%/}"
+
+            # Skip protected folders
+            if echo "$PROTECTED" | grep -qw "$dir"; then
+              echo "KEEP   $dir  (protected)"
+              continue
+            fi
+
+            # Skip if an open PR targets this branch
+            if echo "$OPEN_PR_BRANCHES" | grep -qx "$dir"; then
+              echo "KEEP   $dir  (open PR)"
+              continue
+            fi
+
+            # URL-encode the folder name for the GitHub API
+            # Note: branch names containing '/' are not supported (gh-pages folders cannot contain '/')
+            ENCODED=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$dir")
+
+            # Check if the corresponding branch still exists
+            if ! gh api "repos/$REPO/branches/$ENCODED" > /dev/null 2>&1; then
+              echo "DELETE $dir  (branch not found)"
+              rm -rf "$dir"
+              DELETED=$((DELETED + 1))
+              continue
+            fi
+
+            # Check date of the last commit on that branch
+            LAST_COMMIT_DATE=$(gh api "repos/$REPO/commits?sha=$ENCODED&per_page=1" -q '.[0].commit.committer.date' 2>/dev/null || true)
+
+            if [ -z "$LAST_COMMIT_DATE" ]; then
+              echo "KEEP   $dir  (could not determine last commit date)"
+              continue
+            fi
+
+            LAST_COMMIT_TS=$(date -d "$LAST_COMMIT_DATE" +%s)
+
+            if [ "$LAST_COMMIT_TS" -lt "$CUTOFF_TS" ]; then
+              echo "DELETE $dir  (no activity since $LAST_COMMIT_DATE)"
+              rm -rf "$dir"
+              DELETED=$((DELETED + 1))
+            else
+              echo "KEEP   $dir  (last commit: $LAST_COMMIT_DATE)"
+            fi
+          done
+
+          if [ "$DELETED" -gt 0 ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "chore: remove $DELETED stale branch deployment(s) from gh-pages"
+            git pull --rebase origin gh-pages
+            git push
+          else
+            echo "Nothing to clean."
+          fi

--- a/expansion-params.json
+++ b/expansion-params.json
@@ -1,0 +1,14 @@
+{
+    "resourceType": "Parameters",
+    "id": "expansion-params",
+    "parameter": [
+        {
+            "name": "system-version",
+            "valueUri": "http://snomed.info/sct|http://snomed.info/sct/11000315107"
+        },
+        {
+          "name": "displayLanguage",
+          "valueCode": "fr-FR"
+        }
+    ]
+}

--- a/ig.ini
+++ b/ig.ini
@@ -3,7 +3,7 @@
 # see comments below for instructions
 
 ig = fsh-generated/resources/ImplementationGuide-ans.fhir.fr.ror.json
-template = ans.fr.template#0.2.0
+template = ans.fr.template#main
 
 
 

--- a/ig.ini
+++ b/ig.ini
@@ -3,7 +3,7 @@
 # see comments below for instructions
 
 ig = fsh-generated/resources/ImplementationGuide-ans.fhir.fr.ror.json
-template = ans.fr.template#main
+template = ans.fr.template#current
 
 
 

--- a/input/pagecontent/downloads.md
+++ b/input/pagecontent/downloads.md
@@ -6,20 +6,20 @@ Pour cela, il suffit de télécharger le [package.tgz](package.tgz) et l'importe
 
 Ensemble des ressources téléchargeables :
 
-* [L'ensemble de la specification (zip)](full-ig.zip)
-* [Package (tgz)](package.tgz)
+* [L'ensemble de la specification (zip)](../full-ig.zip)
+* [Package (tgz)](../package.tgz)
 
 #### Définitions
 
-* [Définitions JSON (zip)](definitions.json.zip)
-* [Définitions XML (zip)](definitions.xml.zip)
-* [Définitions Turtle (zip)](definitions.ttl.zip)
+* [Définitions JSON (zip)](../definitions.json.zip)
+* [Définitions XML (zip)](../definitions.xml.zip)
+* [Définitions Turtle (zip)](../definitions.ttl.zip)
 
 #### Exemples
 
-* [Exemples XML (zip)](examples.xml.zip)
-* [Exemples JSON (zip)](examples.json.zip)
-* [Exemples Turtle (zip)](examples.ttl.zip)
+* [Exemples XML (zip)](../examples.xml.zip)
+* [Exemples JSON (zip)](../examples.json.zip)
+* [Exemples Turtle (zip)](../examples.ttl.zip)
 
 ### Usage
 

--- a/input/pagecontent/translationinfo.md
+++ b/input/pagecontent/translationinfo.md
@@ -1,0 +1,5 @@
+### Informations sur la traduction
+
+Cette page présente les informations relatives aux traductions disponibles de ce guide d'implémentation.
+
+La version officielle de ce guide est en français. Une traduction anglaise est disponible à titre de démonstration.

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -22,8 +22,23 @@ copyrightYear: 2020+
 releaseLabel: trial-implementation
 jurisdiction: urn:iso:std:iso:3166#FR "France (la)"
 
-parameters:
+parameters: #Parameters list - https://build.fhir.org/ig/FHIR/fhir-tools-ig/CodeSystem-ig-parameters.html
     shownav: 'true'
+    path-expansion-params: '../../expansion-params.json'
+    pin-canonicals: pin-all
+    apply-contact: true
+    logging:
+      - tx
+      - html
+      - generate
+      - init
+      - progress
+    i18n-default-lang: fr
+    apply-jurisdiction: true
+    i18n-lang:
+      - en
+    translation-sources:
+      - input/translations/en
 
 
 
@@ -67,6 +82,8 @@ pages:
         title: Mapping FHIR du modèle de données du ROR
     change-log.md:
         title: Historique des versions
+    translationinfo.md:
+        title: Informations sur la traduction
     autres_ressources.md:
         securite.md:
             title: Sécurité


### PR DESCRIPTION
## Description des changements

* Passage au template 2 (`ans.fr.template#main`) : mise à jour de `ig.ini`, ajout des `parameters` requis dans `sushi-config.yaml` (`path-expansion-params`, `i18n-default-lang`, `i18n-lang`, `translation-sources`, etc.), ajout de `expansion-params.json` et de la page `translationinfo.md`, correction des liens de téléchargement dans `downloads.md` (préfixe `../` requis par la nouvelle arborescence multilingue). Voir [la procédure de passage au template 2](https://github.com/ansforge/IG-documentation/wiki/Passage-au-template-2). La génération des fichiers de traduction `.po` (`input/translations/en`) sera faite dans une étape séparée après un premier build.
* Ajout du workflow `.github/workflows/clean-gh-pages.yml` (repris de [interop-IG-document-core](https://github.com/ansforge/interop-IG-document-core/blob/main/.github/workflows/clean-gh-pages.yml)) : nettoyage manuel (`workflow_dispatch`) des dossiers de déploiement `gh-pages` correspondant à des branches supprimées ou inactives depuis 30 jours sans PR ouverte.

## Preview

https://ansforge.github.io/IG-fhir-repertoire-offre-ressources-sante/template2-and-clean-gh-pages/ig pour prévisualiser l'IG d'une branche

## Impact API ROR

Aucun impact sur l'API ROR : changements de configuration de publication de l'IG (template, internationalisation) et d'outillage CI, aucun changement sur les profils, ressources FHIR ou la spécification de l'API.